### PR TITLE
Add support for jiff, no_std, const and implement core::error::Error.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,11 @@ keywords = ["easter", "date", "calendar", "gregorian", "julian"]
 readme = "README.md"
 license = "MIT"
 edition = "2021"
+rust-version = "1.81"
 
 [dependencies]
 chrono = { version = ">=0.2.0", optional = true }
+jiff = { version = ">=0.1", optional = true }
 
 [dev-dependencies]
 rstest = { version = "0.17.0", defaut-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,18 @@
 //! ### Overview
-//! 
+//!
 //! Calculate the date of Easter Sunday in Gregorian/Julian calendar using the [computus](https://simple.wikipedia.org/wiki/Computus) method.
-//! 
+//!
 //! ### Features
 //!
 //! Optional features:
 //!
 //! - [`chrono`][]: Enable directly producing a `chrono::NaiveDate`
+//! - [`jiff`][]: Enable directly producing a `jiff::civil::Date`
 //!
 //! ### Example
-//! 
+//!
 //! You can find when Easter is for a particular year with:
-//! 
+//!
 //! ```rust
 //! // For Gregorian calendars
 //! let easter = computus::gregorian(2016).unwrap();
@@ -25,8 +26,14 @@
 //!     let easter = computus::gregorian_naive(2023).unwrap();
 //!     assert_eq!((easter.month(), easter.day()), (4, 9));
 //! }
+//! // With `jiff` feature
+//! #[cfg(feature = "jiff")] {
+//!     use jiff::civil::Date;
+//!     let easter = computus::gregorian_jiff_date(2023).unwrap();
+//!     assert_eq!((easter.month(), easter.day()), (4, 9));
+//! }
 //! ```
-//! 
+//!
 #![no_std]
 
 #[cfg(test)]


### PR DESCRIPTION
Jiff (https://github.com/BurntSushi/jiff) is a new date-time library that is an alternative to `chrono`.

Everything in this crate already seem to support `no_std`, so I enabled it.

Both `gregorian()` and `julian()` are now `const` since which allows them to be used as static constants on compile time.

Returning strings makes the error messages harder to work with in functions that automatically wraps the error (like `anyhow`). This implements a proper type for it that implements `core::error::Error`. This is however a fairly modern feature that requires at least Rust `1.81.0`. I have therefore added `rust-version` to the package specification.